### PR TITLE
Fix link to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A "native-like" desktop app for [Android Messages](https://www.messagesfordesktop.com/). This desktop app is supported by both [Nativefier](https://github.com/jiahaog/nativefier) and [Electron](https://github.com/electron/electron) version `^1.7.6`.
 
-The Mac, Windows, and Linux apps can be downloaded from the [latest release](https://github.com/kelyvin/Android-Messages-Desktop-App/releases).
+The Mac, Windows, and Linux apps can be downloaded from the [latest release](https://github.com/kelyvin/Android-Messages-For-Desktop/releases).
 
 ## Purpose
 The purpose of this project is to build dedicated native-like desktop apps for Android Messages and leverage your OS's built in notification system.


### PR DESCRIPTION
Hey @kelyvin, I tried to download the release but it was pointing to an old Github URL that 404d. This should fix things in the README.